### PR TITLE
Added returntype to function duti_default_app_for_type

### DIFF
--- a/handler.c
+++ b/handler.c
@@ -687,7 +687,7 @@ duti_extension_cleanup:
   return rc;
 }
 
-duti_default_app_for_type(char *osType) {
+int duti_default_app_for_type(char *osType) {
   union {
     OSType  typeAsOSType;
     char    typeAsString[4];


### PR DESCRIPTION
Make complained about missing returntype on the function "duti_default_app_for_type", so I've add int as the type - as it seems to be correct.